### PR TITLE
Added auto-update on plugin start setting

### DIFF
--- a/src/Settings.as
+++ b/src/Settings.as
@@ -12,3 +12,6 @@ string Setting_BaseURL = "http://opdev.local/";
 
 [Setting category="Advanced" name="Verbose API log"]
 bool Setting_VerboseLog = false;
+
+[Setting category="Advanced" name="Auto-update plugins (only at game start)"]
+bool Setting_PerformAutoUpdates = false;

--- a/src/UpdateCheck.as
+++ b/src/UpdateCheck.as
@@ -98,7 +98,8 @@ void CheckForUpdatesAsync()
 	}
 }
 
-void CheckForUpdatesAsyncStartUp() {
+void CheckForUpdatesAsyncStartUp()
+{
 	CheckForUpdatesAsync();
 	if (g_availableUpdates.Length > 0 && Setting_PerformAutoUpdates) {
 		for (uint i = 0; i < g_availableUpdates.Length; i++) {

--- a/src/UpdateCheck.as
+++ b/src/UpdateCheck.as
@@ -97,3 +97,13 @@ void CheckForUpdatesAsync()
 		trace("No plugin updates found!");
 	}
 }
+
+void CheckForUpdatesAsyncStartUp() {
+	CheckForUpdatesAsync();
+	if (g_availableUpdates.Length > 0 && Setting_PerformAutoUpdates) {
+		for (uint i = 0; i < g_availableUpdates.Length; i++) {
+			auto au = g_availableUpdates[i];
+			startnew(PluginUpdateAsync, au);
+		}
+	}
+}

--- a/src/main.as
+++ b/src/main.as
@@ -6,7 +6,7 @@ void Main()
 	@g_fontHeader = Resources::GetFont("DroidSans-Bold.ttf", 24);
 
 	// Start checking for updates immediately
-	CheckForUpdatesAsync();
+	CheckForUpdatesAsyncStartUp();
 
 	// Every 30 minutes, check for updates again
 	while (true) {


### PR DESCRIPTION
Why did I make a separate function for this?
- Compared to a global "is this the first time running" bool, this seems more logical
- Compared to using a bool = false parameter in the CheckForUpdatesAsync() thats just called once in main, this doesnt require making a ref container for the boolean when the function is called with startnew()

Also sad that you woudln't accept the bonus mentioned in #1 