### PR TITLE
infinite scroll

### DIFF
--- a/src/Interface/Tabs/PluginList.as
+++ b/src/Interface/Tabs/PluginList.as
@@ -62,9 +62,10 @@ class PluginListTab : Tab
 		StartRequestForPage(0);
 	}
 
-	void StartRequestForPage(int page) {
+	void StartRequestForPage(int page)
+	{
 		dictionary params;
-		params['page'] = '' + page;
+		params['page'] = tostring(page);
 		GetRequestParams(params);
 
 		string urlParams = "";
@@ -146,7 +147,6 @@ class PluginListTab : Tab
 
 		if (m_request !is null && m_pageCount == 0) {
 			UI::Text("Loading list..");
-			m_lastPageRequestFinished = Time::Now;
 			return;
 		}
 
@@ -176,7 +176,7 @@ class PluginListTab : Tab
 			if (haveMorePages) {
 				UI::TableNextRow(UI::TableRowFlags::None, rowHeight);
 				UI::TableNextColumn();
-				string infiniteScrollMsg = (m_request is null ? "Scroll to Load" : "Loading") + " Page " + (m_page + 2);
+				string infiniteScrollMsg = (m_request is null ? "Scroll to load" : "Loading") + " page " + (m_page + 2);
 				UI::Dummy(vec2(0, rowHeight / 3.0));
 				UI::Text(infiniteScrollMsg);
 			}


### PR DESCRIPTION
fixes #15

note: while in draft this PR probably contains a bunch of dev code -- i didn't know how else to get it to run alongside the normal plugin manager (but this seems to work). This will be removed for the final PR.

explanation of code bits:

**`m_initialListRendered`**: to avoid immediately triggering a request for the 2nd page, `m_initialListRendered` is false for the first frame. (On that frame `UI::GetScrollMaxY()` returns 0 always. We still want to potentially request more pages when `GetScrollMaxY` is 0, though, because this condition is met with a tall thin window.)

**infinite scroll**: it's pretty crude atm. basically we estimate the row height, and if the user get's close to viewing the last row then we initiate a request. The maths is pretty rough and works *well enough* but occasionally a page can be requested early if the user is very near the bottom (common with page 2 or 3). Suggestions welcome wrt improvements, but it's 80% atm so IDK if it's worth bothering with.
