### PR TITLE
Plugin changelogs and unsigned plugin indication

### DIFF
--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -47,7 +47,7 @@ namespace Controls
 
 					if (UI::IsItemHovered()) {					
 						UI::BeginTooltip();
-						UI::Dummy(vec2(512,1)); // SetNextItemWidth wasnt working :(
+						UI::Dummy(vec2(512,0)); // SetNextItemWidth wasnt working :(
 						PluginChangelog(plugin, true);
 						UI::EndTooltip();
 					}

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -31,7 +31,7 @@ namespace Controls
 				DrawTag(tagPos, Icons::ArrowCircleUp + " Update!", Controls::TAG_COLOR_WARNING);
 
 				// if updatable, show changelog in tooltip
-				if(UI::IsItemHovered()) {
+				if(Setting_ChangelogTooltips && UI::IsItemHovered()) {
 					UI::BeginTooltip();
 					UI::Dummy(vec2(512,1)); // SetNextItemWidth wasnt working :(
 					PluginChangelog(plugin, true);

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -31,15 +31,26 @@ namespace Controls
 			// Draw an updatable tag on top of the image if it's installed and updatable
 			if (GetAvailableUpdate(plugin.m_siteID) !is null) {
 				tagPos = windowPos + imagePos + vec2(6, 6 + (30*tagRow));
-				DrawTag(tagPos, Icons::ArrowCircleUp + " Update!", Controls::TAG_COLOR_WARNING);
+				string text = Icons::ArrowCircleUp + " Update!";
+				DrawTag(tagPos, text, Controls::TAG_COLOR_WARNING);
 				tagRow++;
 
 				// if updatable, show changelog in tooltip
-				if(Setting_ChangelogTooltips && UI::IsItemHovered()) {
-					UI::BeginTooltip();
-					UI::Dummy(vec2(512,1)); // SetNextItemWidth wasnt working :(
-					PluginChangelog(plugin, true);
-					UI::EndTooltip();
+				if(Setting_ChangelogTooltips) {
+					// hacky invisible button to tooltip only on tag and not entire PluginCard
+					vec2 cursor = UI::GetCursorPos();
+					UI::SetCursorPos(tagPos - windowPos);
+					vec2 textSize = Draw::MeasureString(text);
+					vec2 tagSize = textSize + Controls::TAG_PADDING * 2;
+					UI::InvisibleButton(plugin.m_id + "_updatable", tagSize);
+					UI::SetCursorPos(cursor);
+
+					if (UI::IsItemHovered()) {					
+						UI::BeginTooltip();
+						UI::Dummy(vec2(512,1)); // SetNextItemWidth wasnt working :(
+						PluginChangelog(plugin, true);
+						UI::EndTooltip();
+					}
 				}
 			}
 		}

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -26,7 +26,7 @@ namespace Controls
 			DrawTag(tagPos, Icons::CheckCircle + " Installed", Controls::TAG_COLOR_PRIMARY);
 
 			// Draw an updatable tag on top of the image if it's installed and updatable
-			if (true) {
+			if (GetAvailableUpdate(plugin.m_siteID) !is null) {
 				tagPos = windowPos + imagePos + vec2(6, 36);
 				DrawTag(tagPos, Icons::ArrowCircleUp + " Update!", Controls::TAG_COLOR_WARNING);
 

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -39,7 +39,7 @@ namespace Controls
 					if (UI::IsItemHovered()) {
 						UI::SetNextWindowSize(400, -1, UI::Cond::Always);
 						UI::BeginTooltip();
-						PluginChangelog(plugin, true);
+						PluginChangelogList(plugin, true);
 						UI::EndTooltip();
 					}
 				}

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -21,14 +21,18 @@ namespace Controls
 		}
 
 		// Draw an installed tag on top of the image if it's installed
+		uint tagRow = 0;
+		vec2 tagPos;
 		if (plugin.GetInstalledPlugin() !is null) {
-			vec2 tagPos = windowPos + imagePos + vec2(6, 6);
+			tagPos = windowPos + imagePos + vec2(6, 6 + (30*tagRow));
 			DrawTag(tagPos, Icons::CheckCircle + " Installed", Controls::TAG_COLOR_PRIMARY);
+			tagRow++;
 
 			// Draw an updatable tag on top of the image if it's installed and updatable
 			if (GetAvailableUpdate(plugin.m_siteID) !is null) {
-				tagPos = windowPos + imagePos + vec2(6, 36);
+				tagPos = windowPos + imagePos + vec2(6, 6 + (30*tagRow));
 				DrawTag(tagPos, Icons::ArrowCircleUp + " Update!", Controls::TAG_COLOR_WARNING);
+				tagRow++;
 
 				// if updatable, show changelog in tooltip
 				if(Setting_ChangelogTooltips && UI::IsItemHovered()) {
@@ -37,6 +41,28 @@ namespace Controls
 					PluginChangelog(plugin, true);
 					UI::EndTooltip();
 				}
+			}
+		}
+
+		// draw alert if unsigned
+		if (!plugin.m_signed) {
+			tagPos = windowPos + imagePos + vec2(6, 6 + (30*tagRow));
+			string text = Icons::Code + " Unsigned";
+			DrawTag(tagPos, text, Controls::TAG_COLOR_DARK);
+			tagRow++;
+
+			// hacky invisible button to tooltip only on tag and not entire PluginCard
+			vec2 cursor = UI::GetCursorPos();
+			UI::SetCursorPos(tagPos - windowPos);
+			vec2 textSize = Draw::MeasureString(text);
+			vec2 tagSize = textSize + Controls::TAG_PADDING * 2;
+			UI::InvisibleButton(plugin.m_id + "_unsigned", tagSize);
+			UI::SetCursorPos(cursor);
+
+			if (UI::IsItemHovered()) {
+				UI::BeginTooltip();
+				UI::Text("This plugin is unsigned and requires developer mode.");
+				UI::EndTooltip();
 			}
 		}
 

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -32,19 +32,10 @@ namespace Controls
 			if (GetAvailableUpdate(plugin.m_siteID) !is null) {
 				tagPos = windowPos + imagePos + vec2(6, 6 + (30*tagRow));
 				string text = Icons::ArrowCircleUp + " Update!";
-				DrawTag(tagPos, text, Controls::TAG_COLOR_WARNING);
+				DrawTagWithInvisButton(tagPos, windowPos, text, Controls::TAG_COLOR_WARNING);
 				tagRow++;
 
-				// if updatable, show changelog in tooltip
 				if(Setting_ChangelogTooltips) {
-					// hacky invisible button to tooltip only on tag and not entire PluginCard
-					vec2 cursor = UI::GetCursorPos();
-					UI::SetCursorPos(tagPos - windowPos);
-					vec2 textSize = Draw::MeasureString(text);
-					vec2 tagSize = textSize + Controls::TAG_PADDING * 2;
-					UI::InvisibleButton(plugin.m_id + "_updatable", tagSize);
-					UI::SetCursorPos(cursor);
-
 					if (UI::IsItemHovered()) {
 						UI::SetNextWindowSize(400, -1, UI::Cond::Always);
 						UI::BeginTooltip();
@@ -59,16 +50,8 @@ namespace Controls
 		if (!plugin.m_signed) {
 			tagPos = windowPos + imagePos + vec2(6, 6 + (30*tagRow));
 			string text = Icons::Code + " Unsigned";
-			DrawTag(tagPos, text, Controls::TAG_COLOR_DARK);
+			DrawTagWithInvisButton(tagPos, windowPos, text, Controls::TAG_COLOR_DARK);
 			tagRow++;
-
-			// hacky invisible button to tooltip only on tag and not entire PluginCard
-			vec2 cursor = UI::GetCursorPos();
-			UI::SetCursorPos(tagPos - windowPos);
-			vec2 textSize = Draw::MeasureString(text);
-			vec2 tagSize = textSize + Controls::TAG_PADDING * 2;
-			UI::InvisibleButton(plugin.m_id + "_unsigned", tagSize);
-			UI::SetCursorPos(cursor);
 
 			if (UI::IsItemHovered()) {
 				UI::BeginTooltip();

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -26,9 +26,17 @@ namespace Controls
 			DrawTag(tagPos, Icons::CheckCircle + " Installed", Controls::TAG_COLOR_PRIMARY);
 
 			// Draw an updatable tag on top of the image if it's installed and updatable
-			if (GetAvailableUpdate(plugin.m_siteID) !is null) {
+			if (true) {
 				tagPos = windowPos + imagePos + vec2(6, 36);
 				DrawTag(tagPos, Icons::ArrowCircleUp + " Update!", Controls::TAG_COLOR_WARNING);
+
+				// if updatable, show changelog in tooltip
+				if(UI::IsItemHovered()) {
+					UI::BeginTooltip();
+					UI::Dummy(vec2(512,1)); // SetNextItemWidth wasnt working :(
+					PluginChangelog(plugin, true);
+					UI::EndTooltip();
+				}
 			}
 		}
 

--- a/src/Interface/Controls/PluginChangelog.as
+++ b/src/Interface/Controls/PluginChangelog.as
@@ -1,0 +1,45 @@
+namespace Controls {
+    void PluginChangelog(PluginInfo@ plugin, bool onlyUpdates = false) {
+		for (uint i = 0; i < plugin.m_changelog.Length; i++) {
+			Changelog@ v = plugin.m_changelog[i];
+			string title;
+            Version installedVersion = plugin.getInstalledVersion();
+
+            if (onlyUpdates && v.m_version <= installedVersion) {
+                continue;
+            }
+
+            if (v.m_postTime > Time::Stamp - 86400) {
+                title = v.m_version.ToString() + " - " + Time::FormatString("%X", v.m_postTime); // use time for plugins released today
+            } else {
+                title = v.m_version.ToString() + " - " + Time::FormatString("%x", v.m_postTime); // otherwise use date
+            }
+            
+            if (i > 0) UI::Separator();
+			UI::PushFont(g_fontSubHeader);
+            if (plugin.m_isInstalled && installedVersion == v.m_version) {
+                UI::Text(title + " (installed)");
+            } else {
+                UI::Text(title);
+            }
+            if (!v.m_isSigned) {
+                UI::SameLine();
+                UI::TextDisabled(Icons::Code + " Unsigned");
+                UI::PopFont();
+                if (UI::IsItemHovered()) {
+                    UI::BeginTooltip();
+                    UI::Text("This release is unsigned and requires developer mode.");
+                    UI::EndTooltip();
+                }
+            } else {
+                UI::PopFont();
+            }
+
+            if (v.m_changeMessage.Length == 0 && i == (plugin.m_changelog.Length-1)) {
+                UI::Markdown("*Initial release*");
+            } else {
+                UI::Markdown(v.m_changeMessage);
+            }
+        }
+    }
+}

--- a/src/Interface/Controls/PluginChangelog.as
+++ b/src/Interface/Controls/PluginChangelog.as
@@ -1,9 +1,9 @@
 namespace Controls
 {
-    void PluginChangelog(PluginInfo@ plugin, bool onlyUpdates = false)
+    void PluginChangelogList(PluginInfo@ plugin, bool onlyUpdates = false)
     {
 		for (uint i = 0; i < plugin.m_changelogs.Length; i++) {
-			Changelog@ v = plugin.m_changelogs[i];
+			PluginChangelog@ v = plugin.m_changelogs[i];
             Version installedVersion = plugin.GetInstalledVersion();
 
             if (onlyUpdates && v.m_version <= installedVersion) {

--- a/src/Interface/Controls/PluginChangelog.as
+++ b/src/Interface/Controls/PluginChangelog.as
@@ -1,21 +1,27 @@
-namespace Controls {
-    void PluginChangelog(PluginInfo@ plugin, bool onlyUpdates = false) {
-		for (uint i = 0; i < plugin.m_changelog.Length; i++) {
-			Changelog@ v = plugin.m_changelog[i];
-			string title;
-            Version installedVersion = plugin.getInstalledVersion();
+namespace Controls
+{
+    void PluginChangelog(PluginInfo@ plugin, bool onlyUpdates = false)
+    {
+		for (uint i = 0; i < plugin.m_changelogs.Length; i++) {
+			Changelog@ v = plugin.m_changelogs[i];
+            Version installedVersion = plugin.GetInstalledVersion();
 
             if (onlyUpdates && v.m_version <= installedVersion) {
                 continue;
             }
 
+            string date;
             if (v.m_postTime > Time::Stamp - 86400) {
-                title = v.m_version.ToString() + " - " + Time::FormatString("%X", v.m_postTime); // use time for plugins released today
+                date = Time::FormatString("%X", v.m_postTime); // use time for plugins released today
             } else {
-                title = v.m_version.ToString() + " - " + Time::FormatString("%x", v.m_postTime); // otherwise use date
+                date = Time::FormatString("%x", v.m_postTime); // otherwise use date
             }
+            string title = v.m_version.ToString() + " - " + date;
             
-            if (i > 0) UI::Separator();
+            if (i > 0) {
+                UI::Separator();
+            }
+
 			UI::PushFont(g_fontSubHeader);
             if (plugin.m_isInstalled && installedVersion == v.m_version) {
                 UI::Text(title + " (installed)");
@@ -25,17 +31,15 @@ namespace Controls {
             if (!v.m_isSigned) {
                 UI::SameLine();
                 UI::TextDisabled(Icons::Code + " Unsigned");
-                UI::PopFont();
-                if (UI::IsItemHovered()) {
-                    UI::BeginTooltip();
-                    UI::Text("This release is unsigned and requires developer mode.");
-                    UI::EndTooltip();
-                }
-            } else {
-                UI::PopFont();
+            }
+            UI::PopFont();
+            if (!v.m_isSigned && UI::IsItemHovered()) {
+                UI::BeginTooltip();
+                UI::Text("This release is unsigned and requires developer mode.");
+                UI::EndTooltip();
             }
 
-            if (v.m_changeMessage.Length == 0 && i == (plugin.m_changelog.Length-1)) {
+            if (v.m_changeMessage.Length == 0 && i == (plugin.m_changelogs.Length-1)) {
                 UI::Markdown("*Initial release*");
             } else {
                 UI::Markdown(v.m_changeMessage);

--- a/src/Interface/Controls/Tag.as
+++ b/src/Interface/Controls/Tag.as
@@ -26,6 +26,17 @@ namespace Controls
 		return DrawTag(vec4(pos.x, pos.y, tagSize.x, tagSize.y), text, color);
 	}
 
+	vec4 DrawTagWithInvisButton(const vec2 &in pos, const vec2 &in windowPos, const string &in text, const vec4 &in color = TAG_COLOR) {
+		vec4 ret = DrawTag(pos, text, color);
+
+		vec2 cursor = UI::GetCursorPos();
+		UI::SetCursorPos(pos - windowPos);
+		UI::InvisibleButton("", ret.zw);
+		UI::SetCursorPos(cursor);
+
+		return ret;
+	}
+
 	void Tag(const string &in text, const vec4 &in color = TAG_COLOR)
 	{
 		vec2 textSize = Draw::MeasureString(text);

--- a/src/Interface/Controls/Tag.as
+++ b/src/Interface/Controls/Tag.as
@@ -26,7 +26,8 @@ namespace Controls
 		return DrawTag(vec4(pos.x, pos.y, tagSize.x, tagSize.y), text, color);
 	}
 
-	vec4 DrawTagWithInvisButton(const vec2 &in pos, const vec2 &in windowPos, const string &in text, const vec4 &in color = TAG_COLOR) {
+	vec4 DrawTagWithInvisButton(const vec2 &in pos, const vec2 &in windowPos, const string &in text, const vec4 &in color = TAG_COLOR)
+	{
 		vec4 ret = DrawTag(pos, text, color);
 
 		vec2 cursor = UI::GetCursorPos();

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -328,6 +328,8 @@ class PluginTab : Tab
 						UI::Text("This release is unsigned and requires developer mode.");
 						UI::EndTooltip();
 					}
+				} else {
+					UI::PopFont();
 				}
 
 				if (v.m_changeMessage.Length == 0 && i == (m_plugin.m_changelog.Length-1)) {

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -79,7 +79,7 @@ class PluginTab : Tab
 				warn(js["error"]);
 			} else {
 				for (uint i = 0; i < js.Length; i++) {
-					m_plugin.m_changelogs.InsertLast(Changelog(js[i]));
+					m_plugin.m_changelogs.InsertLast(PluginChangelog(js[i]));
 				}
 			}
 		}
@@ -326,7 +326,7 @@ class PluginTab : Tab
 		if (m_plugin.m_changelogs.Length == 0) {
 			UI::Text(m_changelogFillerMessage);
 		} else {
-			Controls::PluginChangelog(m_plugin, false);
+			Controls::PluginChangelogList(m_plugin, false);
 		}
 
 		UI::EndChild();

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -299,45 +299,11 @@ class PluginTab : Tab
 		UI::Text("Versions");
 		UI::PopFont();
 
+		UI::Separator();
 		if (m_plugin.m_changelog.Length == 0) {
 			UI::Text(m_changelogFillerMessage);
 		} else {
-			for (uint i = 0; i < m_plugin.m_changelog.Length; i++) {
-				UI::Separator();
-				Changelog@ v = m_plugin.m_changelog[i];
-				UI::PushFont(g_fontSubHeader);
-				string title;
-				Version installedVersion = m_plugin.getInstalledVersion();
-				if (v.m_postTime > Time::Stamp - 86400) {
-					title = v.m_version.ToString() + " - " + Time::FormatString("%X", v.m_postTime); // use time for plugins released today
-				} else {
-					title = v.m_version.ToString() + " - " + Time::FormatString("%x", v.m_postTime); // otherwise use date
-				}
-				
-				if (m_plugin.m_isInstalled && installedVersion == v.m_version) {
-					UI::Text(title + " (installed)");
-				} else {
-					UI::Text(title);
-				}
-				if (!v.m_isSigned) {
-					UI::SameLine();
-					UI::TextDisabled(Icons::Code + " Unsigned");
-					UI::PopFont();
-					if (UI::IsItemHovered()) {
-						UI::BeginTooltip();
-						UI::Text("This release is unsigned and requires developer mode.");
-						UI::EndTooltip();
-					}
-				} else {
-					UI::PopFont();
-				}
-
-				if (v.m_changeMessage.Length == 0 && i == (m_plugin.m_changelog.Length-1)) {
-					UI::Markdown("*Initial release*");
-				} else {
-					UI::Markdown(v.m_changeMessage);
-				}
-			}
+			Controls::PluginChangelog(m_plugin, false);
 		}
 
 		UI::EndChild();

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -300,7 +300,7 @@ class PluginTab : Tab
 		UI::PopFont();
 
 		UI::Separator();
-		if (m_plugin.m_changelog.Length == 0) {
+		if (m_plugin.m_changelogs.Length == 0) {
 			UI::Text(m_changelogFillerMessage);
 		} else {
 			Controls::PluginChangelog(m_plugin, false);

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -319,7 +319,16 @@ class PluginTab : Tab
 				} else {
 					UI::Text(title);
 				}
-				UI::PopFont();
+				if (!v.m_isSigned) {
+					UI::SameLine();
+					UI::TextDisabled(Icons::Code + " Unsigned");
+					UI::PopFont();
+					if (UI::IsItemHovered()) {
+						UI::BeginTooltip();
+						UI::Text("This release is unsigned and requires developer mode.");
+						UI::EndTooltip();
+					}
+				}
 
 				if (v.m_changeMessage.Length == 0 && i == (m_plugin.m_changelog.Length-1)) {
 					UI::Markdown("*Initial release*");

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -64,18 +64,19 @@ class PluginTab : Tab
 	void CheckRequestChangelog()
 	{
 		// If there's a request, check if it has finished
-		if (m_requestMain !is null && m_requestMain.Finished() && m_plugin !is null) {
+		if (m_requestChangelog !is null && m_requestChangelog.Finished() && m_plugin !is null) {
 			// Parse the response
-			string res = m_requestMain.String();
-			int resCode = m_requestMain.ResponseCode();
-			@m_requestMain = null;
+			string res = m_requestChangelog.String();
+			int resCode = m_requestChangelog.ResponseCode();
+			@m_requestChangelog = null;
 			auto js = Json::Parse(res);
 
 			// Handle the response
-			if (js.GetType() != Json::Type::Object) {
-				HandleErrorResponse(res, resCode);
-			} else if (js.HasKey("error")) {
-				HandleErrorResponse(js["error"], resCode);
+			if (js.GetType() != Json::Type::Array) {
+				m_changelogFillerMessage = "Error fetching changelog. :(";
+			} else if (js.GetType() == Json::Type::Object && js.HasKey("error")) {
+				m_changelogFillerMessage = "Error fetching changelog. :(";
+				warn(js["error"]);
 			} else {
 				for (uint i = 0; i < js.Length; i++) {
 					m_plugin.m_changelogs.InsertLast(Changelog(js[i]));
@@ -87,9 +88,6 @@ class PluginTab : Tab
 	void HandleResponse(const Json::Value &in js)
 	{
 		@m_plugin = PluginInfo(js);
-		if (!m_plugin.LoadChangelog()) {
-			m_changelogFillerMessage = "Error fetching changelog. :(";
-		}
 	}
 
 	void HandleErrorResponse(const string &in message, int code)

--- a/src/Interface/Tabs/PluginList.as
+++ b/src/Interface/Tabs/PluginList.as
@@ -117,7 +117,7 @@ class PluginListTab : Tab
 		auto jsItems = js["items"];
 		for (uint i = 0; i < jsItems.Length; i++) {
 			PluginInfo pi(jsItems[i]);
-			if (pi.getInstalledVersion() < pi.m_version) {
+			if (Setting_ChangelogTooltips && pi.getInstalledVersion() < pi.m_version) {
 				pi.LoadChangelog();
 			}
 			m_plugins.InsertLast(pi);

--- a/src/Interface/Tabs/PluginList.as
+++ b/src/Interface/Tabs/PluginList.as
@@ -10,7 +10,6 @@ class PluginListTab : Tab
 	int m_pageCount;
 
 	array<PluginInfo@> m_plugins;
-	array<PluginInfo@> m_pluginsWithChangelogs;
 
 	string GetLabel() override { return "Plugins"; }
 
@@ -121,18 +120,16 @@ class PluginListTab : Tab
 			PluginInfo pi(jsItems[i]);
 			if (Setting_ChangelogTooltips && pi.GetInstalledVersion() < pi.m_version) {
 				pi.LoadChangelog();
-				m_pluginsWithChangelogs.InsertLast(pi);
 			}
 			m_plugins.InsertLast(pi);
 		}
 	}
 
 	void CheckChangelogRequests() {
-		for (uint i = 0; i < m_pluginsWithChangelogs.Length; i++) {
-			PluginInfo@ pi = m_pluginsWithChangelogs[i];
-			if (pi.m_changelogs.Length > 0 || pi.m_changelogRequest.Error().Length > 0) {
-				m_pluginsWithChangelogs.RemoveAt(i);
-				return;
+		for (uint i = 0; i < m_plugins.Length; i++) {
+			PluginInfo@ pi = m_plugins[i];
+			if (pi.m_changelogs.Length > 0 || pi.m_changelogRequest is null || pi.m_changelogRequest.Error().Length > 0) {
+				continue;
 			}
 			pi.CheckChangelog();
 		}

--- a/src/Interface/Tabs/PluginList.as
+++ b/src/Interface/Tabs/PluginList.as
@@ -116,7 +116,11 @@ class PluginListTab : Tab
 
 		auto jsItems = js["items"];
 		for (uint i = 0; i < jsItems.Length; i++) {
-			m_plugins.InsertLast(PluginInfo(jsItems[i]));
+			PluginInfo pi(jsItems[i]);
+			if (pi.getInstalledVersion() < pi.m_version) {
+				pi.LoadChangelog();
+			}
+			m_plugins.InsertLast(pi);
 		}
 	}
 

--- a/src/Interface/Tabs/PluginList.as
+++ b/src/Interface/Tabs/PluginList.as
@@ -125,7 +125,8 @@ class PluginListTab : Tab
 		}
 	}
 
-	void CheckChangelogRequests() {
+	void CheckChangelogRequests()
+	{
 		for (uint i = 0; i < m_plugins.Length; i++) {
 			PluginInfo@ pi = m_plugins[i];
 			if (pi.m_changelogs.Length > 0 || pi.m_changelogRequest is null || pi.m_changelogRequest.Error().Length > 0) {
@@ -178,6 +179,4 @@ class PluginListTab : Tab
 			UI::EndTable();
 		}
 	}
-
-
 }

--- a/src/Interface/Tabs/PluginList.as
+++ b/src/Interface/Tabs/PluginList.as
@@ -117,7 +117,7 @@ class PluginListTab : Tab
 		auto jsItems = js["items"];
 		for (uint i = 0; i < jsItems.Length; i++) {
 			PluginInfo pi(jsItems[i]);
-			if (Setting_ChangelogTooltips && pi.getInstalledVersion() < pi.m_version) {
+			if (Setting_ChangelogTooltips && pi.GetInstalledVersion() < pi.m_version) {
 				pi.LoadChangelog();
 			}
 			m_plugins.InsertLast(pi);

--- a/src/Interface/Tabs/PluginList.as
+++ b/src/Interface/Tabs/PluginList.as
@@ -8,7 +8,9 @@ class PluginListTab : Tab
 	int m_total;
 	int m_page;
 	int m_pageCount;
+
 	array<PluginInfo@> m_plugins;
+	array<PluginInfo@> m_pluginsWithChangelogs;
 
 	string GetLabel() override { return "Plugins"; }
 
@@ -119,8 +121,20 @@ class PluginListTab : Tab
 			PluginInfo pi(jsItems[i]);
 			if (Setting_ChangelogTooltips && pi.GetInstalledVersion() < pi.m_version) {
 				pi.LoadChangelog();
+				m_pluginsWithChangelogs.InsertLast(pi);
 			}
 			m_plugins.InsertLast(pi);
+		}
+	}
+
+	void CheckChangelogRequests() {
+		for (uint i = 0; i < m_pluginsWithChangelogs.Length; i++) {
+			PluginInfo@ pi = m_pluginsWithChangelogs[i];
+			if (pi.m_changelogs.Length > 0 || pi.m_changelogRequest.Error().Length > 0) {
+				m_pluginsWithChangelogs.RemoveAt(i);
+				return;
+			}
+			pi.CheckChangelog();
 		}
 	}
 
@@ -139,6 +153,7 @@ class PluginListTab : Tab
 	void Render() override
 	{
 		CheckRequest();
+		CheckChangelogRequests();
 
 		if (m_request !is null) {
 			UI::Text("Loading list..");
@@ -166,4 +181,6 @@ class PluginListTab : Tab
 			UI::EndTable();
 		}
 	}
+
+
 }

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -7,6 +7,9 @@ bool Setting_ColoredUsernames = true;
 [Setting category="Interface" name="Plugins per row" min=1 max=10]
 int Setting_PluginsPerRow = 3;
 
+[Setting category="Interface" name="Display changelog when hovering over updatable plugins."]
+bool Setting_ChangelogTooltips = true;
+
 [Setting category="Advanced" name="Base URL" description="Only change if you know what you're doing!"]
 string Setting_BaseURL = "https://openplanet.dev/";
 

--- a/src/Utils/PluginChangelog.as
+++ b/src/Utils/PluginChangelog.as
@@ -1,0 +1,17 @@
+class PluginChangelog
+{
+	int m_siteID;
+	int64 m_postTime;
+	Version m_version;
+    bool m_isSigned;
+    string m_changeMessage;
+
+	PluginChangelog(const Json::Value &in js)
+	{
+		m_siteID = js["id"];
+		m_postTime = js["posttime"];
+		m_version = Version(js["version"]);
+		m_isSigned = js["signed"];
+		m_changeMessage = js["changes"];
+	}
+}

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -132,7 +132,6 @@ class PluginInfo
 		for (uint i = 0; i < js.Length; i++) {
 			m_changelogs.InsertLast(PluginChangelog(js[i]));
 		}
-		return;
 	}
 
 	Version GetInstalledVersion()

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -109,11 +109,13 @@ class PluginInfo
 		}
 	}
 
-	void LoadChangelog() {
+	void LoadChangelog() 
+	{
 		@m_changelogRequest = API::Get("plugin/" + m_siteID + "/versions");
 	}
 
-	void CheckChangelog() {
+	void CheckChangelog()
+	{
 		if (m_changelogRequest is null || !m_changelogRequest.Finished()) {
 			return;
 		}

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -167,10 +167,12 @@ class PluginInfo
 		return;
 	}
 
-	Version GetInstalledVersion() {
-		if (!m_isInstalled) {
+	Version GetInstalledVersion()
+	{
+		auto _plugin = Meta::GetPluginFromSiteID(m_siteID);
+		if (!m_isInstalled || _plugin !is null) {
 			return Version("0.0.0");
 		}
-		return Version(Meta::GetPluginFromSiteID(m_siteID).Version);
+		return Version(_plugin.Version);
 	}
 }

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -58,8 +58,7 @@ class PluginInfo
 	array<string> m_screenshots;
 
 	array<TagInfo@> m_tags;
-
-	array<Changelog@> m_changelog;
+	array<Changelog@> m_changelogs;
 
 	bool m_isInstalled;
 
@@ -154,13 +153,12 @@ class PluginInfo
 		}
 
 		for (uint i = 0; i < js.Length; i++) {
-			Changelog cl(js[i]);
-			m_changelog.InsertLast(cl);
+			m_changelogs.InsertLast(Changelog(js[i]));
 		}
 		return true;
 	}
 
-	Version getInstalledVersion() {
+	Version GetInstalledVersion() {
 		if (!m_isInstalled) {
 			return Version("0.0.0");
 		}

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -170,7 +170,7 @@ class PluginInfo
 	Version GetInstalledVersion()
 	{
 		auto _plugin = Meta::GetPluginFromSiteID(m_siteID);
-		if (!m_isInstalled || _plugin !is null) {
+		if (!m_isInstalled || _plugin is null) {
 			return Version("0.0.0");
 		}
 		return Version(_plugin.Version);

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -1,37 +1,3 @@
-class TagInfo
-{
-	string m_type;
-	string m_name;
-	string m_class;
-	string m_tooltip;
-
-	TagInfo(const Json::Value &in js)
-	{
-		m_type = js["type"];
-		m_name = js["name"];
-		m_class = js["class"];
-		m_tooltip = js["tooltip"];
-	}
-}
-
-class Changelog
-{
-	int m_siteID;
-	int64 m_postTime;
-	Version m_version;
-    bool m_isSigned;
-    string m_changeMessage;
-
-	Changelog(const Json::Value &in js)
-	{
-		m_siteID = js["id"];
-		m_postTime = js["posttime"];
-		m_version = Version(js["version"]);
-		m_isSigned = js["signed"];
-		m_changeMessage = js["changes"];
-	}
-}
-
 class PluginInfo
 {
 	int m_siteID;
@@ -58,7 +24,7 @@ class PluginInfo
 	array<string> m_screenshots;
 
 	array<TagInfo@> m_tags;
-	array<Changelog@> m_changelogs;
+	array<PluginChangelog@> m_changelogs;
 
 	bool m_isInstalled;
 
@@ -162,17 +128,17 @@ class PluginInfo
 		}
 
 		for (uint i = 0; i < js.Length; i++) {
-			m_changelogs.InsertLast(Changelog(js[i]));
+			m_changelogs.InsertLast(PluginChangelog(js[i]));
 		}
 		return;
 	}
 
 	Version GetInstalledVersion()
 	{
-		auto _plugin = Meta::GetPluginFromSiteID(m_siteID);
-		if (!m_isInstalled || _plugin is null) {
+		auto plugin = Meta::GetPluginFromSiteID(m_siteID);
+		if (!m_isInstalled || plugin is null) {
 			return Version("0.0.0");
 		}
-		return Version(_plugin.Version);
+		return Version(plugin.Version);
 	}
 }

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -114,7 +114,7 @@ class PluginInfo
 	}
 
 	void CheckChangelog() {
-		if (!m_changelogRequest.Finished()) {
+		if (m_changelogRequest is null || !m_changelogRequest.Finished()) {
 			return;
 		}
 

--- a/src/Utils/TagInfo.as
+++ b/src/Utils/TagInfo.as
@@ -1,0 +1,15 @@
+class TagInfo
+{
+	string m_type;
+	string m_name;
+	string m_class;
+	string m_tooltip;
+
+	TagInfo(const Json::Value &in js)
+	{
+		m_type = js["type"];
+		m_name = js["name"];
+		m_class = js["class"];
+		m_tooltip = js["tooltip"];
+	}
+}

--- a/src/main.as
+++ b/src/main.as
@@ -1,9 +1,11 @@
 UI::Font@ g_fontHeader;
+UI::Font@ g_fontSubHeader;
 
 void Main()
 {
 	// Load header font
 	@g_fontHeader = UI::LoadFont("DroidSans.ttf", 26);
+	@g_fontSubHeader = UI::LoadFont("DroidSans.ttf", 20);
 
 	// Load plugin cache
 	PluginCache::Initialize();


### PR DESCRIPTION
Resolves #4, Resolves #11, Resolves #19

* Adds a changelog to the main Plugin page, below the description
* Adds a changelog tooltip when hovering over updatable plugins (toggleable with settings bool)
* Adds a notice tag when plugins are unsigned.