### PR TITLE
Dependency manager (tab to see plugin deps to make installation easier)

### DIFF
--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -5,6 +5,11 @@ class DependencyManagerTab : Tab
 	string COLOR_RN = Icons::Circle;
 	string COLOR_ON = Icons::CircleO;
 
+	uint DEPTH_LIMIT = 5;
+
+	DepLeaf@[] seen; // used to prevent infinite loops
+	DepLeaf@[] tree;
+
 	string GetLabel() override { return "Dependencies"; }
 
 	vec4 GetColor() override { return vec4(0, 0.6f, 0.2f, 1); }
@@ -15,6 +20,10 @@ class DependencyManagerTab : Tab
 
 	void Render() override
 	{
+		if (tree.Length == 0) {
+			LoadDependencyTree();
+		}
+
 		if (!Setting_ColorblindDependencies) {
 			COLOR_RI = "\\$z" + COLOR_RI;
 			COLOR_OI = "\\$666" + COLOR_OI;
@@ -34,111 +43,98 @@ class DependencyManagerTab : Tab
 			UI::TableNextColumn();
 		UI::Text(COLOR_ON + "Optional dependency (not installed)");
 			UI::EndTable();
+			if (UI::Button("Rescan dependencies")) {
+				LoadDependencyTree();
+				return;
+			}
 			UI::Separator();
 		}
 
+		for (uint i = 0; i < tree.Length; i++) {
+			DrawPluginLeaf(tree[i], 0, true);
+		}
+	}
+
+	void DrawPluginLeaf(DepLeaf@ plugin, uint depth, bool required)
+	{
+		string colorTag;
+
+		if (plugin.m_plugin !is null) { // plugin is installed
+			colorTag = required ? COLOR_RI : COLOR_OI;
+			string pluginText = InstalledPluginString(plugin);
+			// don't go too deep
+			if (depth > DEPTH_LIMIT) {
+				UI::TreeAdvanceToLabelPos();
+				UI::Text(colorTag + pluginText);
+			} else {
+				if (UI::TreeNode(colorTag + pluginText, UI::TreeNodeFlags::Leaf)) {
+					for (uint i = 0; i < plugin.m_requiredChilds.Length; i++) {
+						DrawPluginLeaf(plugin.m_requiredChilds[i], depth+1, true);
+					}
+					for (uint i = 0; i < plugin.m_optionalChilds.Length; i++) {
+						DrawPluginLeaf(plugin.m_optionalChilds[i], depth+1, false);
+					}
+					UI::TreePop();
+				}
+			}
+
+		} else if (plugin.m_apiObj !is null) { // we have openplanet.dev deets
+			colorTag = required ? COLOR_RN : COLOR_ON;
+			UI::TreeAdvanceToLabelPos();
+			UI::Text(colorTag + NotInstalledPluginString(plugin) + "\\$z");
+			UI::SameLine();
+			if (UI::Button(Icons::InfoCircle + "###" + plugin.m_ident)) {
+				g_window.AddTab(PluginTab(plugin.m_siteID), true);
+			}
+		} else { // we got no fukken clue
+			colorTag = required ? COLOR_RN : COLOR_ON;
+			UI::TreeAdvanceToLabelPos();
+			UI::Text(colorTag + MysteryPluginString(plugin) + "\\$z");
+			UI::SameLine();
+			if (UI::ColoredButton(Icons::ExclamationTriangle, 0.f)) {
+				OpenBrowserURL("https://openplanet.dev/plugin/"+plugin.m_ident);
+			}
+			if (UI::IsItemHovered()) {
+				UI::BeginTooltip();
+				UI::Text("Plugin identifier not found. Click to search on Openplanet.dev.");
+				UI::EndTooltip();
+			}
+		}
+	}
+
+	string InstalledPluginString(DepLeaf@ plugin) {
+		return plugin.m_name +
+		    " \\$999by " + plugin.m_author +
+			" \\$666(v" + plugin.m_plugin.Version + " installed)";
+	}
+
+	string NotInstalledPluginString(DepLeaf@ plugin) {
+		return plugin.m_name +
+		    " \\$999by " + plugin.m_author;
+	}
+
+	string MysteryPluginString(DepLeaf@ plugin) {
+		return plugin.m_ident;
+	}
+
+	void LoadDependencyTree() {
+		trace("Reloading dependency tree...");
+		seen.Resize(0);
+		tree.Resize(0);
+
+		// first let's populate our top-levels
 		Meta::Plugin@[] loaded = Meta::AllPlugins();
 		for (uint i = 0; i < loaded.Length; i++) {
 			Meta::Plugin@ v = loaded[i];
-
-			if (v.Dependencies.Length == 0 && v.OptionalDependencies.Length == 0) {
-				continue;
-			} else {
-				string[] inChain;
-				DepLeaf(v, inChain, true, false);
-			}
-		}
-	}
-
-	void DepLeaf(Meta::Plugin@ plugin, string[]@ inChain, bool topLevel, bool isOptional)
-	{
-		if (plugin.Dependencies.Length == 0 && plugin.OptionalDependencies.Length == 0) {
-			_DepLeafNoChilds(plugin, isOptional, topLevel);
-			return;
+			DepLeaf x = DepLeaf(loaded[i]);
+			tree.InsertLast(x);
+			seen.InsertLast(x);
 		}
 
-		string nameColorTag = isOptional ? COLOR_OI : COLOR_RI;
-		int flags = topLevel ? UI::TreeNodeFlags::DefaultOpen : UI::TreeNodeFlags::None;
-		if (UI::TreeNode(nameColorTag + GetPluginTitleString(plugin, topLevel), flags)) {
-			if (inChain.Find(plugin.ID) >= 0) {
-				UI::TreeAdvanceToLabelPos();
-				UI::Text("Circular dependency detected...");
-				UI::TreePop();
-				return;
-			}
-			inChain.InsertLast(plugin.ID);
-
-			for (uint i = 0; i < plugin.Dependencies.Length; i++) {
-				_DepLeaf(plugin.Dependencies[i], inChain, false);
-			}
-			for (uint i = 0; i < plugin.OptionalDependencies.Length; i++) {
-				_DepLeaf(plugin.OptionalDependencies[i], inChain, true);
-			}
-			UI::TreePop();
+		// now iterate through and add dependencies
+		for (uint i = 0; i < tree.Length; i++) {
+			tree[i].PopulateChilds(seen);
 		}
-	}
-
-	void _DepLeafNoChilds(Meta::Plugin@ plugin, bool isOptional, bool isTopLevel)
-	{	
-		string nameColorTag = isOptional ? COLOR_OI : COLOR_RI;
-		UI::TreeAdvanceToLabelPos();
-		UI::Text(nameColorTag + GetPluginTitleString(plugin, isTopLevel));
-	}
-
-	string GetPluginTitleString(Meta::Plugin@ plugin, bool isTopLevel) {
-		string name = _GetPluginTitleString(plugin.Name, plugin.Author);
-		if (isTopLevel) {
-			name += " (v" + plugin.Version + " installed)";
-		}
-		return name;
-	}
-
-	string GetPluginTitleString(Json::Value@ plugin) {
-		return _GetPluginTitleString(plugin["name"], plugin["author"]);
-	}
-
-	string _GetPluginTitleString(const string &in pluginName, const string &in author) {
-		return pluginName + " \\$999by " + author;
-	}
-
-	void _DepLeaf(const string &in dep, string[]@ inChain, bool isOptional)
-	{
-		Meta::Plugin@ child = Meta::GetPluginFromID(dep);
-		if (child !is null) {
-			DepLeaf(child, inChain, false, isOptional);
-		} else {
-			int APIcacheRef = PluginIdentToSiteIDRef(dep);
-
-			string nameColorTag = isOptional ? COLOR_ON : COLOR_RN;
-			UI::TreeAdvanceToLabelPos();
-			if (APIcacheRef == -1) { // could not find in api cache
-				UI::Text(nameColorTag + dep + "\\$z");
-				UI::SameLine();
-				if (UI::ColoredButton(Icons::ExclamationTriangle, 0.f)) {
-					OpenBrowserURL("https://openplanet.dev/plugin/"+dep);
-				}
-				if (UI::IsItemHovered()) {
-					UI::BeginTooltip();
-					UI::Text("Plugin identifier not found. Click to search on Openplanet.dev.");
-					UI::EndTooltip();
-				}
-			} else {
-				Json::Value apiRet = g_cachedAPIPluginList[APIcacheRef];
-				UI::Text(nameColorTag + GetPluginTitleString(apiRet) + "\\$z");
-				UI::SameLine();
-				if (UI::Button(Icons::InfoCircle + "###"+dep)) {
-					g_window.AddTab(PluginTab(g_cachedAPIPluginList[APIcacheRef]['id']), true);
-				}
-			}
-		}
-	}
-
-	int PluginIdentToSiteIDRef(const string &in ident) {
-		for (uint i = 0; i < g_cachedAPIPluginList.Length; i++) {
-			if (g_cachedAPIPluginList[i]["identifier"] == ident) {
-				return i;
-			}
-		}
-		return -1;
+		trace("Scanned " + seen.Length + " plugins.");
 	}
 }

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -116,7 +116,7 @@ class DependencyManagerTab : Tab
 			UI::TreeAdvanceToLabelPos();
 			UI::Text(colorTag + MysteryPluginString(plugin) + "\\$z");
 			UI::SameLine();
-			if (UI::ColoredButton(Icons::ExclamationTriangle, 0.f)) {
+			if (UI::ColoredButton(Icons::ExclamationTriangle+ "###" + plugin.m_ident, 0.f)) {
 				OpenBrowserURL("https://openplanet.dev/plugin/"+plugin.m_ident);
 			}
 			if (UI::IsItemHovered()) {

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -22,14 +22,20 @@ class DependencyManagerTab : Tab
 			COLOR_ON = "\\$f88" + COLOR_ON;
 		}
 
-		UI::Text(COLOR_RI + "Required dependency  ");
-		UI::SameLine();
-		UI::Text(COLOR_OI + "Optional dependency  ");
-		UI::SameLine();
-		UI::Text(COLOR_RN + "Required dependency (not installed)  ");
-		UI::SameLine();
-		UI::Text(COLOR_ON + "Optional dependency (not installed)  ");
-		UI::Separator();
+		if (UI::BeginTable("legend", 2, UI::TableFlags::SizingStretchSame)) {
+			UI::TableNextRow();
+			UI::TableNextColumn();
+			UI::Text(COLOR_RI + "Required dependency");
+			UI::TableNextColumn();
+			UI::Text(COLOR_OI + "Optional dependency");
+			UI::TableNextRow();
+			UI::TableNextColumn();
+		UI::Text(COLOR_RN + "Required dependency (not installed)");
+			UI::TableNextColumn();
+		UI::Text(COLOR_ON + "Optional dependency (not installed)");
+			UI::EndTable();
+			UI::Separator();
+		}
 
 		Meta::Plugin@[] loaded = Meta::AllPlugins();
 		for (uint i = 0; i < loaded.Length; i++) {

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -22,9 +22,9 @@ class DependencyManagerTab : Tab
 		}
 	}
 
-	string GetLabel() override { return "Dependencies"; }
+	string GetLabel() override { return Icons::CheckSquareO + " Dependencies"; }
 
-	vec4 GetColor() override { return vec4(0, 0.6f, 0.2f, 1); }
+	vec4 GetColor() override { return vec4(0.6f, 0.6f, 0.f, 1); }
 
 	void RenderEmpty()
 	{

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -127,22 +127,26 @@ class DependencyManagerTab : Tab
 		}
 	}
 
-	string InstalledPluginString(DepLeaf@ plugin) {
+	string InstalledPluginString(DepLeaf@ plugin)
+	{
 		return plugin.m_name +
 		    " \\$999by " + plugin.m_author +
 			" \\$666(v" + plugin.m_plugin.Version + " installed)";
 	}
 
-	string NotInstalledPluginString(DepLeaf@ plugin) {
+	string NotInstalledPluginString(DepLeaf@ plugin)
+	{
 		return plugin.m_name +
 		    " \\$999by " + plugin.m_author;
 	}
 
-	string MysteryPluginString(DepLeaf@ plugin) {
+	string MysteryPluginString(DepLeaf@ plugin)
+	{
 		return plugin.m_ident;
 	}
 
-	void LoadDependencyTree() {
+	void LoadDependencyTree()
+	{
 		trace("Reloading dependency tree...");
 		seen.Resize(0);
 		tree.Resize(0);

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -67,7 +67,7 @@ class DependencyManagerTab : Tab
 				UI::TreeAdvanceToLabelPos();
 				UI::Text(colorTag + pluginText);
 			} else {
-				if (UI::TreeNode(colorTag + pluginText, UI::TreeNodeFlags::Leaf)) {
+				if (UI::TreeNode(colorTag + pluginText)) {
 					for (uint i = 0; i < plugin.m_requiredChilds.Length; i++) {
 						DrawPluginLeaf(plugin.m_requiredChilds[i], depth+1, true);
 					}

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -1,0 +1,89 @@
+class DependencyManagerTab : Tab
+{
+
+	string GetLabel() override { return "Dependencies"; }
+
+	vec4 GetColor() override { return vec4(0, 0.6f, 0.2f, 1); }
+
+	void RenderEmpty()
+	{
+	}
+
+	void Render() override
+	{
+
+		Meta::Plugin@[] loaded = Meta::AllPlugins();
+		for (uint i = 0; i < loaded.Length; i++) {
+			Meta::Plugin@ v = loaded[i];
+
+			if (v.Dependencies.Length == 0 && v.OptionalDependencies.Length == 0) {
+				continue;
+			} else {
+				string[] inChain;
+				DepLeaf(v, inChain, true, false);
+			}
+		}
+	}
+
+	void DepLeaf(Meta::Plugin@ plugin, string[]@ inChain, bool topLevel, bool isOptional)
+	{
+		if (plugin.Dependencies.Length == 0 && plugin.OptionalDependencies.Length == 0) {
+			_DepLeafNoChilds(plugin, isOptional);
+			return;
+		}
+
+		int flags = topLevel ? UI::TreeNodeFlags::DefaultOpen : UI::TreeNodeFlags::None;
+		if (UI::TreeNode(_GetPluginTitleString(plugin, isOptional), flags)) {
+			if (inChain.Find(plugin.ID) >= 0) {
+				UI::TreeAdvanceToLabelPos();
+				UI::Text("Circular dependency detected...");
+				UI::TreePop();
+				return;
+			}
+			inChain.InsertLast(plugin.ID);
+
+			for (uint i = 0; i < plugin.Dependencies.Length; i++) {
+				_DepLeaf(plugin.Dependencies[i], inChain, false);
+			}
+			for (uint i = 0; i < plugin.OptionalDependencies.Length; i++) {
+				_DepLeaf(plugin.OptionalDependencies[i], inChain, true);
+			}
+			UI::TreePop();
+		}
+	}
+
+	void _DepLeafNoChilds(Meta::Plugin@ plugin, bool isOptional)
+	{	
+		UI::TreeAdvanceToLabelPos();
+		UI::Text(_GetPluginTitleString(plugin, isOptional));
+	}
+
+	string _GetPluginTitleString(Meta::Plugin@ plugin, bool isOptional) {
+		string name = plugin.Name;
+		if (isOptional) {
+			name = "\\$666" + name;
+		}
+		name += " by " + plugin.Author + " (v" + plugin.Version + ")";
+		return name;
+	}
+
+	void _DepLeaf(const string &in dep, string[]@ inChain, bool isOptional)
+	{
+		Meta::Plugin@ child = Meta::GetPluginFromID(dep);
+		if (child !is null) {
+			DepLeaf(child, inChain, false, isOptional);
+		} else {
+			string name = dep;
+			if (isOptional) {
+				name = "\\$666" + name;
+			}
+			UI::TreeAdvanceToLabelPos();
+			UI::Text(name + " \\$f00(not installed)\\$z");
+			UI::SameLine();
+			if (UI::Button("Info###"+dep, vec2(0, UI::GetTextLineHeight()))) {
+				// todo: is there a better way to do this? search by ident instead of siteID would be gr8
+				g_window.AddTab(SearchTab(dep), true);
+			}
+		}
+	}
+}

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -1,10 +1,9 @@
 class DependencyManagerTab : Tab
 {
-
-	string COLOR_RI = "\\$z";
-	string COLOR_OI = "\\$666";
-	string COLOR_RN = "\\$f00";
-	string COLOR_ON = "\\$f88";
+	string COLOR_RI = Icons::CheckCircle;
+	string COLOR_OI = Icons::CheckCircleO;
+	string COLOR_RN = Icons::Circle;
+	string COLOR_ON = Icons::CircleO;
 
 	string GetLabel() override { return "Dependencies"; }
 
@@ -16,6 +15,12 @@ class DependencyManagerTab : Tab
 
 	void Render() override
 	{
+		if (!Setting_ColorblindDependencies) {
+			COLOR_RI = "\\$z" + COLOR_RI;
+			COLOR_OI = "\\$666" + COLOR_OI;
+			COLOR_RN = "\\$f00" + COLOR_RN;
+			COLOR_ON = "\\$f88" + COLOR_ON;
+		}
 
 		UI::Text(COLOR_RI + "Required dependency  ");
 		UI::SameLine();

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -81,9 +81,17 @@ class DependencyManagerTab : Tab
 			UI::Text(name + " \\$f00(not installed)\\$z");
 			UI::SameLine();
 			if (UI::Button("Info###"+dep, vec2(0, UI::GetTextLineHeight()))) {
-				// todo: is there a better way to do this? search by ident instead of siteID would be gr8
-				g_window.AddTab(SearchTab(dep), true);
+				g_window.AddTab(PluginTab(PluginIdentToSiteID(dep)), true);
 			}
 		}
+	}
+
+	int PluginIdentToSiteID(const string &in ident) {
+		for (uint i = 0; i < g_cachedAPIPluginList.Length; i++) {
+			if (g_cachedAPIPluginList[i]["identifier"] == ident) {
+				return g_cachedAPIPluginList[i]["id"];
+			}
+		}
+		return -1;
 	}
 }

--- a/src/Interface/Tabs/DependencyManager.as
+++ b/src/Interface/Tabs/DependencyManager.as
@@ -12,6 +12,16 @@ class DependencyManagerTab : Tab
 
 	bool showAllPlugins = false;
 
+	DependencyManagerTab()
+	{
+		if (!Setting_ColorblindDependencies) {
+			COLOR_RI = "\\$z" + COLOR_RI;
+			COLOR_OI = "\\$666" + COLOR_OI;
+			COLOR_RN = "\\$f00" + COLOR_RN;
+			COLOR_ON = "\\$666" + COLOR_ON;
+		}
+	}
+
 	string GetLabel() override { return "Dependencies"; }
 
 	vec4 GetColor() override { return vec4(0, 0.6f, 0.2f, 1); }
@@ -24,13 +34,6 @@ class DependencyManagerTab : Tab
 	{
 		if (tree.Length == 0) {
 			LoadDependencyTree();
-		}
-
-		if (!Setting_ColorblindDependencies) {
-			COLOR_RI = "\\$z" + COLOR_RI;
-			COLOR_OI = "\\$666" + COLOR_OI;
-			COLOR_RN = "\\$f00" + COLOR_RN;
-			COLOR_ON = "\\$f88" + COLOR_ON;
 		}
 
 		if (UI::BeginTable("legend", 2, UI::TableFlags::SizingStretchSame)) {

--- a/src/Interface/Tabs/Search.as
+++ b/src/Interface/Tabs/Search.as
@@ -1,27 +1,9 @@
 class SearchTab : PluginListTab
 {
 	string m_search;
-	bool m_closable = false;
 	uint64 m_typingStart;
 
-	SearchTab() {}
-	SearchTab(const string &in ident)
-	{
-		m_search = ident;
-		m_closable = true;
-		StartRequest();
-	}
-
-	bool CanClose() override { return m_closable; }
-
-	string GetLabel() override
-	{
-		if (m_closable) {
-			return Icons::Search + " " + m_search + "###Search";
-		} else {
-			return Icons::Search + " Search###Search";
-		}
-	}
+	string GetLabel() override { return Icons::Search + " Search###Search"; }
 
 	void GetRequestParams(dictionary@ params) override
 	{

--- a/src/Interface/Tabs/Search.as
+++ b/src/Interface/Tabs/Search.as
@@ -1,9 +1,27 @@
 class SearchTab : PluginListTab
 {
 	string m_search;
+	bool m_closable = false;
 	uint64 m_typingStart;
 
-	string GetLabel() override { return Icons::Search + " Search###Search"; }
+	SearchTab() {}
+	SearchTab(const string &in ident)
+	{
+		m_search = ident;
+		m_closable = true;
+		StartRequest();
+	}
+
+	bool CanClose() override { return m_closable; }
+
+	string GetLabel() override
+	{
+		if (m_closable) {
+			return Icons::Search + " " + m_search + "###Search";
+		} else {
+			return Icons::Search + " Search###Search";
+		}
+	}
 
 	void GetRequestParams(dictionary@ params) override
 	{

--- a/src/Interface/Window.as
+++ b/src/Interface/Window.as
@@ -9,8 +9,8 @@ class Window
 	Window()
 	{
 		AddTab(UpdatesTab());
-		AddTab(DependencyManagerTab());
 		AddTab(InstalledTab());
+		AddTab(DependencyManagerTab());
 
 		AddTab(FeaturedTab());
 		AddTab(PopularTab());

--- a/src/Interface/Window.as
+++ b/src/Interface/Window.as
@@ -9,6 +9,7 @@ class Window
 	Window()
 	{
 		AddTab(UpdatesTab());
+		AddTab(DependencyManagerTab());
 		AddTab(InstalledTab());
 
 		AddTab(FeaturedTab());

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -7,6 +7,9 @@ bool Setting_ColoredUsernames = true;
 [Setting category="Interface" name="Plugins per row" min=1 max=10]
 int Setting_PluginsPerRow = 3;
 
+[Setting category="Interface" name="Disable colored statuses in Dependency view"]
+bool Setting_ColorblindDependencies = false;
+
 [Setting category="Advanced" name="Base URL" description="Only change if you know what you're doing!"]
 string Setting_BaseURL = "https://openplanet.dev/";
 

--- a/src/Utils/API.as
+++ b/src/Utils/API.as
@@ -24,4 +24,26 @@ namespace API
 		}
 		return Json::Parse(req.String());
 	}
+
+	Json::Value@[] GetPluginListAsync() {
+		uint pages = 1;
+
+		Json::Value@[] plugs;
+
+		for (uint i = 0; i < pages; i++) {
+			Json::Value req = GetAsync("plugins?page=" + i);
+
+			if (pages == 1 && req["pages"] != 1) {
+				pages = req["pages"];
+			}
+
+			for (uint ii = 0; ii < req["items"].Length; ii++) {
+				plugs.InsertLast(req["items"][ii]);
+			}
+
+			// nap a bit so we dont wreck the Openplanet API...
+			sleep(500);
+		}
+		return plugs;
+	}
 }

--- a/src/Utils/API.as
+++ b/src/Utils/API.as
@@ -25,7 +25,8 @@ namespace API
 		return Json::Parse(req.String());
 	}
 
-	void GetPluginListAsync() {
+	void GetPluginListAsync()
+	{
 		uint pages = 1;
 		g_cachedAPIPluginList.Resize(0);
 

--- a/src/Utils/API.as
+++ b/src/Utils/API.as
@@ -25,10 +25,9 @@ namespace API
 		return Json::Parse(req.String());
 	}
 
-	Json::Value@[] GetPluginListAsync() {
+	void GetPluginListAsync() {
 		uint pages = 1;
-
-		Json::Value@[] plugs;
+		g_cachedAPIPluginList.Resize(0);
 
 		for (uint i = 0; i < pages; i++) {
 			Json::Value req = GetAsync("plugins?page=" + i);
@@ -38,12 +37,11 @@ namespace API
 			}
 
 			for (uint ii = 0; ii < req["items"].Length; ii++) {
-				plugs.InsertLast(req["items"][ii]);
+				g_cachedAPIPluginList.InsertLast(req["items"][ii]);
 			}
 
 			// nap a bit so we dont wreck the Openplanet API...
 			sleep(500);
 		}
-		return plugs;
 	}
 }

--- a/src/Utils/DependencyLeaf.as
+++ b/src/Utils/DependencyLeaf.as
@@ -1,0 +1,93 @@
+class DepLeaf {
+	Json::Value@ m_apiObj;
+	Meta::Plugin@ m_plugin;
+
+    string m_ident;
+    int m_siteID;
+
+    string m_name;
+    string m_author;
+    string m_version;
+
+	DepLeaf@[] m_requiredChilds;
+	DepLeaf@[] m_optionalChilds;
+
+    DepLeaf() {}
+
+    DepLeaf(Json::Value@ req)
+    {
+        @m_apiObj = req;
+
+        m_ident = req["identifier"];
+        m_siteID = req["id"];
+        m_name = req["name"];
+        m_author = req["author"];
+    }
+
+    DepLeaf(Meta::Plugin@ plug)
+    {
+        @m_plugin = plug;
+
+        m_ident = plug.ID;
+        m_siteID = plug.SiteID;
+        m_name = plug.Name;
+        m_author = plug.Author;
+        m_version = plug.Version;
+    }
+
+    void PopulateChilds(DepLeaf@[]@ seen)
+    {
+        if (m_plugin is null) {
+            return;
+        }
+
+        _PopulateChilds(seen, m_plugin.Dependencies, m_requiredChilds);
+        _PopulateChilds(seen, m_plugin.OptionalDependencies, m_optionalChilds);
+    }
+
+    void _PopulateChilds(DepLeaf@[]@ seen, string[]@ deps, DepLeaf@[]@ childsArray)
+    {
+        for (uint i = 0; i < deps.Length; i++) {
+            int seenID = GetSeenID(deps[i], seen);
+            if (seenID >= 0) {
+                // we've already seen this plugin, so just add a reference to the array and fuck off
+                childsArray.InsertLast(seen[seenID]);
+                return;
+            }
+
+            // all installed plugins are already "seen" so we gotta get from API
+            int APIcacheRef = PluginIdentToSiteIDRef(deps[i]);
+            DepLeaf x;
+            if (APIcacheRef == -1) { // could not find in api cache
+                x.m_ident = deps[i];
+            } else {
+                Json::Value apiRet = g_cachedAPIPluginList[APIcacheRef];
+                x = DepLeaf(apiRet);
+            }
+            seen.InsertLast(x);
+            childsArray.InsertLast(x);
+            x.PopulateChilds(seen);
+        }
+    }
+
+    int PluginIdentToSiteIDRef(const string &in ident)
+    {
+		for (uint i = 0; i < g_cachedAPIPluginList.Length; i++) {
+			if (g_cachedAPIPluginList[i]["identifier"] == ident) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+    int GetSeenID(const string &in ident, DepLeaf@[]@ seen)
+    {
+		for (uint i = 0; i < seen.Length; i++) {
+			if (seen[i].m_ident == ident) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+}

--- a/src/Utils/DependencyLeaf.as
+++ b/src/Utils/DependencyLeaf.as
@@ -52,7 +52,7 @@ class DepLeaf {
             if (seenID >= 0) {
                 // we've already seen this plugin, so just add a reference to the array and fuck off
                 childsArray.InsertLast(seen[seenID]);
-                return;
+                continue;
             }
 
             // all installed plugins are already "seen" so we gotta get from API

--- a/src/main.as
+++ b/src/main.as
@@ -13,14 +13,14 @@ void Main()
 	CheckForUpdatesAsyncStartUp();
 
 	// load a list of plugins from the API for later use...
-	g_cachedAPIPluginList = API::GetPluginListAsync();
+	API::GetPluginListAsync();
 
 	// Every 30 minutes, check for updates again
 	while (true) {
 		sleep(30 * 60 * 1000);
 		if (Setting_AutoCheckUpdates) {
 			CheckForUpdatesAsync();
-			g_cachedAPIPluginList = API::GetPluginListAsync();
+			API::GetPluginListAsync();
 		}
 	}
 }

--- a/src/main.as
+++ b/src/main.as
@@ -1,4 +1,5 @@
 UI::Font@ g_fontHeader;
+Json::Value@[] g_cachedAPIPluginList;
 
 void Main()
 {
@@ -11,11 +12,15 @@ void Main()
 	// Start checking for updates immediately
 	CheckForUpdatesAsyncStartUp();
 
+	// load a list of plugins from the API for later use...
+	g_cachedAPIPluginList = API::GetPluginListAsync();
+
 	// Every 30 minutes, check for updates again
 	while (true) {
 		sleep(30 * 60 * 1000);
 		if (Setting_AutoCheckUpdates) {
 			CheckForUpdatesAsync();
+			g_cachedAPIPluginList = API::GetPluginListAsync();
 		}
 	}
 }


### PR DESCRIPTION
This isn't quite a fix for #6, but I think it's a good middle point until such time as the API supports dependency autoinstalls.

(That being said, I'm pretty sure you *could* auto-install dependencies without changing the API. It'd be a little jank, but you could store the ident of the plugin you're trying to install, then if it fails, see which `.Dependencies` aren't present. I was considering writing this, but I suspect we'd prefer a more elegant approach. If we wanted to do this, the dep manager pulls all the data to facilitate it)

One item of note is due to API limitations I'm making a few requests to /api/plugins (one for each page). If there was a way to get all items at once, that might make more sense for this. IDK what the server-side limitations are tho.

![image](https://user-images.githubusercontent.com/2791628/217451400-0a0fbc65-70f5-4896-834c-ecbf160f3d9a.png)

