### PR TITLE
Allow arbitrary image ratios in plugin images

### DIFF
--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -15,10 +15,17 @@ namespace Controls
 		auto img = Images::CachedFromURL(plugin.m_image);
 		if (img.m_texture !is null) {
 			vec2 thumbSize = img.m_texture.GetSize();
-			UI::Image(img.m_texture, vec2(
-				width,
-				thumbSize.y / (thumbSize.x / width)
-			));
+
+			float r_width = width / thumbSize.x;
+			float r_height = (270.0f / (480.0f / width)) / thumbSize.y;
+			float coverRatio = Math::Min(r_width, r_height);
+
+			vec2 dst = thumbSize * coverRatio;
+			int sideShift = (width - dst.x) / 2;
+
+			UI::Dummy(vec2(sideShift - (6.0f * scale), 270.0f / (480.0f / width)));
+			UI::SameLine();
+			UI::Image(img.m_texture, dst);
 		} else {
 			float extraPixels = 6.0f * scale;
 			UI::SetCursorPos(UI::GetCursorPos() + vec2(0, 270.0f / (480.0f / width) + extraPixels));

--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -15,17 +15,10 @@ namespace Controls
 		auto img = Images::CachedFromURL(plugin.m_image);
 		if (img.m_texture !is null) {
 			vec2 thumbSize = img.m_texture.GetSize();
-
-			float r_width = width / thumbSize.x;
-			float r_height = (270.0f / (480.0f / width)) / thumbSize.y;
-			float coverRatio = Math::Min(r_width, r_height);
-
-			vec2 dst = thumbSize * coverRatio;
-			int sideShift = (width - dst.x) / 2;
-
-			UI::Dummy(vec2(sideShift - (6.0f * scale), 270.0f / (480.0f / width)));
-			UI::SameLine();
-			UI::Image(img.m_texture, dst);
+			UI::Image(img.m_texture, vec2(
+				width,
+				thumbSize.y / (thumbSize.x / width)
+			));
 		} else {
 			float extraPixels = 6.0f * scale;
 			UI::SetCursorPos(UI::GetCursorPos() + vec2(0, 270.0f / (480.0f / width) + extraPixels));

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -297,6 +297,7 @@ class PluginTab : Tab
 				const float COL_SPACING = 4 * scale;
 
 				float colWidth = (UI::GetWindowSize().x - WINDOW_PADDING * 2 - COL_SPACING * (SCREENSHOTS_PER_ROW - 1)) / float(SCREENSHOTS_PER_ROW);
+				float colHeight = (270.0f / (480.0f / colWidth));
 
 				for (uint i = 0; i < m_plugin.m_screenshots.Length; i++) {
 					string screenshot = m_plugin.m_screenshots[i];
@@ -306,15 +307,25 @@ class PluginTab : Tab
 						vec2 imgSize = imgScreenshot.m_texture.GetSize();
 
 						float r_width = colWidth / imgSize.x;
-						float r_height = (270.0f / (480.0f / colWidth)) / imgSize.y;
+						float r_height = colHeight / imgSize.y;
 						float coverRatio = Math::Min(r_width, r_height);
-
 						vec2 dst = imgSize * coverRatio;
-						int sideShift = (colWidth - dst.x) / 2;
+						float r_diff = r_width - r_height;
 
-						UI::Dummy(vec2(sideShift - (6.0f * scale), 270.0f / (480.0f / colWidth)));
-						UI::SameLine();
-						UI::Image(imgScreenshot.m_texture, dst);
+						if (r_diff > -0.01 && r_diff < 0.01) { // close enough to 16:9
+							UI::Image(imgScreenshot.m_texture, dst);
+						} else if (r_diff >= 0.01) { // tall
+							int sideShift = (colWidth - dst.x) / 2;
+							UI::Dummy(vec2(sideShift - (6.0f * scale), 1));
+							UI::SameLine();
+							UI::Image(imgScreenshot.m_texture, dst);
+						} else { // thicc
+							int sideShift = (colHeight - dst.y) / 2;
+							UI::Dummy(vec2(1, sideShift - (6.0f * scale)));
+							UI::Image(imgScreenshot.m_texture, dst);
+						}
+
+
 
 						if (UI::IsItemHovered()) {
 							UI::BeginTooltip();

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -304,10 +304,17 @@ class PluginTab : Tab
 					auto imgScreenshot = Images::CachedFromURL(screenshot);
 					if (imgScreenshot.m_texture !is null) {
 						vec2 imgSize = imgScreenshot.m_texture.GetSize();
-						UI::Image(imgScreenshot.m_texture, vec2(
-							colWidth,
-							imgSize.y / (imgSize.x / colWidth)
-						));
+
+						float r_width = colWidth / imgSize.x;
+						float r_height = (270.0f / (480.0f / colWidth)) / imgSize.y;
+						float coverRatio = Math::Min(r_width, r_height);
+
+						vec2 dst = imgSize * coverRatio;
+						int sideShift = (colWidth - dst.x) / 2;
+
+						UI::Dummy(vec2(sideShift - (6.0f * scale), 270.0f / (480.0f / colWidth)));
+						UI::SameLine();
+						UI::Image(imgScreenshot.m_texture, dst);
 
 						if (UI::IsItemHovered()) {
 							UI::BeginTooltip();

--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -325,8 +325,6 @@ class PluginTab : Tab
 							UI::Image(imgScreenshot.m_texture, dst);
 						}
 
-
-
 						if (UI::IsItemHovered()) {
 							UI::BeginTooltip();
 							UI::Image(imgScreenshot.m_texture, imgSize / 2.0f);


### PR DESCRIPTION
will provide compatibility for openplanet-nl/website#35 once that drops, in the meantime this of course renders perfectly fine with the existing image ratios

![image](https://github.com/openplanet-nl/plugin-manager/assets/2791628/70ca4fe4-b3aa-4b92-bada-0159b9807757)
![image](https://github.com/openplanet-nl/plugin-manager/assets/2791628/204b70c3-bc3c-417c-97cd-262715ceef45)
