### PR TITLE
Screenshot descriptions

### DIFF
--- a/src/Interface/Tabs/Plugin.as
+++ b/src/Interface/Tabs/Plugin.as
@@ -312,6 +312,9 @@ class PluginTab : Tab
 						if (UI::IsItemHovered()) {
 							UI::BeginTooltip();
 							UI::Image(imgScreenshot.m_texture, imgSize / 2.0f);
+							if (m_plugin.m_screenshotDescriptions[i].Length > 0) {
+								UI::TextWrapped(m_plugin.m_screenshotDescriptions[i]);
+							}
 							UI::EndTooltip();
 						}
 					}

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -24,6 +24,7 @@ class PluginInfo
 	string m_url;
 
 	array<string> m_screenshots;
+	array<string> m_screenshotDescriptions;
 
 	array<TagInfo@> m_tags;
 	array<PluginChangelog@> m_changelogs;
@@ -52,9 +53,9 @@ class PluginInfo
 
         if (js.HasKey("links")) {
             auto jsLinks = js["links"];
-            m_donateURL = jsLinks["donate"].GetType() == Json::Type::String ? jsLinks["donate"] : ""; // setting to null instead of "" crashes openplanet compiler
-            m_sourceURL = jsLinks["source"].GetType() == Json::Type::String ? jsLinks["source"] : "";
-            m_issuesURL = jsLinks["issues"].GetType() == Json::Type::String ? jsLinks["issues"] : "";
+            m_donateURL = NullCoalesce(jsLinks["donate"]);
+            m_sourceURL = NullCoalesce(jsLinks["source"]);
+            m_issuesURL = NullCoalesce(jsLinks["issues"]);
         }
 
 		m_filesize = js["filesize"];
@@ -70,8 +71,9 @@ class PluginInfo
 		auto jsScreenshots = js["screenshots"];
 		for (uint i = 0; i < jsScreenshots.Length; i++) {
 			auto jsScreenshot = jsScreenshots[i];
-			if (jsScreenshot.GetType() == Json::Type::String) {
-				m_screenshots.InsertLast(jsScreenshot);
+			if (jsScreenshot.GetType() == Json::Type::Object) {
+				m_screenshots.InsertLast(jsScreenshot["uri"]);
+				m_screenshotDescriptions.InsertLast(NullCoalesce(jsScreenshot["description"]));
 			}
 		}
 
@@ -162,5 +164,14 @@ class PluginInfo
 			return Version("0.0.0");
 		}
 		return Version(plugin.Version);
+	}
+
+	/**
+	 * one day ?? my beloved will return from the war
+	 */
+	string NullCoalesce(Json::Value j, const string &in ncVal = "")
+	{
+		if (j.GetType() == Json::Type::Null) return ncVal;
+		return j;
 	}
 }

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -74,6 +74,9 @@ class PluginInfo
 			if (jsScreenshot.GetType() == Json::Type::Object) {
 				m_screenshots.InsertLast(jsScreenshot["uri"]);
 				m_screenshotDescriptions.InsertLast(NullCoalesce(jsScreenshot["description"]));
+			} else if (jsScreenshot.GetType() == Json::Type::String) {
+				m_screenshots.InsertLast(string(jsScreenshot));
+				m_screenshotDescriptions.InsertLast("");
 			}
 		}
 


### PR DESCRIPTION
Adds support for PluginScreenshot descriptions added by openplanet-nl/website#39. It adds them to the tooltip shown on hovering over the image.

![image](https://github.com/openplanet-nl/plugin-manager/assets/2791628/ebcb2e92-5bcb-4434-baf3-85d5fdc4a126)
