### PR TITLE
Skip PluginCard if width too small

### DIFF
--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -2,6 +2,8 @@ namespace Controls
 {
 	void PluginCard(PluginInfo@ plugin, float width)
 	{
+		if (width <= 0.0f) { return; }
+
 		float scale = UI::GetScale();
 
 		float tagRowHeight = 30 * scale;


### PR DESCRIPTION
This should resolve openplanet-nl/issues#338

Recreating the issue produces the following log output:
```
[   ScriptRuntime] [19:02:43] [PluginManager]  Script exception: Divide by zero
[   ScriptRuntime] [19:02:43] [PluginManager]    D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Controls/PluginCard.as (line 18, column 4)
[   ScriptRuntime] [19:02:43] [PluginManager]      #0  void Controls::PluginCard(PluginInfo@ plugin, float width) (D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Controls/PluginCard.as line 18)
[   ScriptRuntime] [19:02:43] [PluginManager]      #1  void PluginListTab::Render() (D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tabs/PluginList.as line 181)
[   ScriptRuntime] [19:02:43] [PluginManager]      #2  void InstalledTab::Render() (D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tabs/Installed.as line 59)
[   ScriptRuntime] [19:02:43] [PluginManager]      #3  void Window::RenderTabContents(Tab@ tab) (D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Window.as line 32)
[   ScriptRuntime] [19:02:43] [PluginManager]      #4  void Window::Render() (D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Window.as line 81)
[   ScriptRuntime] [19:02:43] [PluginManager]      #5  void RenderInterface() (D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/main.as line 27)
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Controls/PluginCard.as line 9
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tabs/PluginList.as line 175
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Window.as line 31
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Window.as line 79
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tab.as line 15
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tab.as line 14
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tab.as line 13
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Window.as line 59
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Window.as line 51
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tab.as line 15
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tab.as line 14
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Tab.as line 13
[   ScriptRuntime] [19:02:43]  Unrolling dangling script UI stack: D:\Epic\TrackmaniaNext\Openplanet/Plugins/PluginManager/src/Interface/Window.as line 44
```

As a result of this change, when the plugin manager window becomes very thin all the plugin cards disappear.

Before they disappear: 
![image](https://github.com/openplanet-nl/plugin-manager/assets/52106022/48790e2d-fd61-47bf-90ef-51c51ebc5b55)

After they disappear (slightly thinner): 
![image](https://github.com/openplanet-nl/plugin-manager/assets/52106022/c8b494cc-982d-49ae-b09d-cc313e998617)
