### PR TITLE
show broken plugins on installed tab

### DIFF
--- a/src/Interface/Controls/PluginCard.as
+++ b/src/Interface/Controls/PluginCard.as
@@ -66,6 +66,20 @@ namespace Controls
 			}
 		}
 
+		// also draw alert on broken plugins
+		if (plugin.m_broken) {
+			tagPos = windowPos + imagePos + vec2(6, 6 + (tagRowHeight * tagRow));
+			string text = Icons::ExclamationTriangle + " Broken";
+			DrawTagWithInvisButton(tagPos, windowPos, text, Controls::TAG_COLOR_DANGER);
+			tagRow++;
+
+			if (UI::IsItemHovered()) {
+				UI::BeginTooltip();
+				UI::Text("This plugin is been marked as broken! It may no longer be working as intended, might be broken, or might be very unstable.");
+				UI::EndTooltip();
+			}
+		}
+
 		// Remember where our text will go
 		vec2 textPos = UI::GetCursorPos();
 

--- a/src/Interface/Tabs/Installed.as
+++ b/src/Interface/Tabs/Installed.as
@@ -38,6 +38,7 @@ class InstalledTab : PluginListTab
 			listIds += tostring(ids[i]);
 		}
 		params.Set("ids", listIds);
+		params.Set("filterBroken", "false");
 	}
 
 	void StartRequest() override

--- a/src/Utils/PluginInfo.as
+++ b/src/Utils/PluginInfo.as
@@ -15,6 +15,7 @@ class PluginInfo
 
 	uint m_filesize;
 	bool m_signed;
+	bool m_broken;
 
 	int64 m_postTime;
 	int64 m_updateTime;
@@ -60,6 +61,7 @@ class PluginInfo
 
 		m_filesize = js["filesize"];
 		m_signed = js["signed"];
+		m_broken = js["broken"];
 
 		m_postTime = js["posttime"];
 		m_updateTime = js["updatetime"];


### PR DESCRIPTION
shows broken plugins on the installed tab with a little warning

wont function without openplanet-nl/website#45 obvs

![image](https://github.com/openplanet-nl/plugin-manager/assets/2791628/ef8b0ae5-cf8a-4cce-ac22-9594626a5ea1)
