### PR TITLE
Draft: Add pagination option

### DIFF
--- a/src/Interface/Controls/Pagination.as
+++ b/src/Interface/Controls/Pagination.as
@@ -1,0 +1,53 @@
+namespace Controls
+{
+    class Pagination {
+
+        int page = 0;
+        int total = 0;
+        int pageCount = 0;
+
+        int m_limit = 3;
+
+        bool isPageRequested = false;
+        int requestedPageIndex = 0;
+
+        void Render() {
+            isPageRequested = false;
+            requestedPageIndex = 0;
+
+            if (page > 0) {
+                PageButton(page - 1, "Prev Page");
+            }
+
+            UI::BeginGroup();
+            for (uint i = Math::Max(0, page - m_limit); i < page; i++) {
+                PageButton(i);
+            }
+
+            UI::BeginDisabled();
+            PageButton(page);
+
+            UI::EndDisabled();
+            
+            for (uint i = page + 1; i < Math::Min(pageCount, page + m_limit + 1); i++) {
+                PageButton(i);
+            }
+
+            if (pageCount > page + 1) {
+                PageButton(page + 1, "Next Page");
+            }
+            UI::EndGroup();
+        }
+
+        void PageButton(int pageIndex, string label = "") {
+            if (label == "") {
+                label = "" + (pageIndex + 1);
+            }
+            if (UI::Button(label)) {
+                isPageRequested = true;
+                requestedPageIndex = pageIndex;
+            }
+            UI::SameLine();
+        }
+    }
+}

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -10,11 +10,14 @@ int Setting_PluginsPerRow = 3;
 [Setting category="Interface" name="Display changelog when hovering over updatable plugins."]
 bool Setting_ChangelogTooltips = true;
 
+[Setting category="Interface" name="Enable tabs pagination"]
+bool Setting_TabsPagination = true;
+
 [Setting category="Advanced" name="Base URL" description="Only change if you know what you're doing!"]
 string Setting_BaseURL = "https://openplanet.dev/";
 
 [Setting category="Advanced" name="Verbose logging (useful for development)"]
-bool Setting_VerboseLog = false;
+bool Setting_VerboseLog = true;
 
 [Setting category="Advanced" name="Auto-update plugins on game startup"]
 bool Setting_PerformAutoUpdates = false;


### PR DESCRIPTION
 I was bothered that every time I go to plugin page from any tab I need to scroll again to get back... so I added an option to enable pagination.
 
 If you leave tab and get back again you end up on page you left from.
 I don't know if it really needed but it's working draft.