### PR TITLE
don't update folder plugins

### DIFF
--- a/src/PluginCache.as
+++ b/src/PluginCache.as
@@ -67,7 +67,7 @@ namespace PluginCache
 		}
 		js["installed"] = jsInstalled;
 
-		Json::ToFile(pathInstalled, js);
+		Json::ToFile(pathInstalled, js, true);
 
 		if (Setting_VerboseLog) {
 			trace("Saved PluginCache.json");

--- a/src/Update.as
+++ b/src/Update.as
@@ -1,6 +1,11 @@
 void PluginUninstallAsync(ref@ metaPlugin)
 {
 	auto plugin = cast<Meta::Plugin@>(metaPlugin);
+	if (plugin.Type != Meta::PluginType::Zip) {
+		warn("Can't uninstall plugin, not a zip: " + plugin.Name);
+		return;
+	}
+
 	string pluginSourcePath = plugin.SourcePath;
 	string pluginIdentifier = plugin.ID;
 
@@ -56,6 +61,11 @@ void PluginUpdateAsync(ref@ update)
 	// If the plugin is currently loaded
 	auto installedPlugin = Meta::GetPluginFromSiteID(au.m_siteID);
 	if (installedPlugin !is null) {
+		if (installedPlugin.Type != Meta::PluginType::Zip) {
+			warn("Unable to update plugin " + installedPlugin.Name + " because it is not a zip!");
+			return;
+		}
+
 		// Gather dependency index and start topological sort
 		auto index = Meta::PluginIndex();
 		index.AddTree(installedPlugin);
@@ -93,17 +103,25 @@ void UpdateAllPluginsAsync()
 	for (uint i = 0; i < g_availableUpdates.Length; i++) {
 		auto au = g_availableUpdates[i];
 		auto installedPlugin = Meta::GetPluginFromSiteID(au.m_siteID);
-		if (installedPlugin !is null) {
+		if (installedPlugin !is null && installedPlugin.Type == Meta::PluginType::Zip) {
 			index.AddTree(installedPlugin);
 		}
 	}
 	auto sortedPlugins = index.TopologicalSort();
+
+	uint[] removeIndices;
 
 	// Uninstall and install the new version of each plugin
 	for (uint i = 0; i < g_availableUpdates.Length; i++) {
 		auto au = g_availableUpdates[i];
 		auto installedPlugin = Meta::GetPluginFromSiteID(au.m_siteID);
 		if (installedPlugin !is null) {
+			if (installedPlugin.Type != Meta::PluginType::Zip) {
+				warn("Unable to update plugin " + installedPlugin.Name + " because it is not a zip!");
+				removeIndices.InsertLast(i);
+				continue;
+			}
+
 			// Uninstall the plugin (this will also unload dependents)
 			PluginUninstallAsync(installedPlugin);
 			@installedPlugin = null;
@@ -118,6 +136,10 @@ void UpdateAllPluginsAsync()
 			// Install and load the plugin
 			PluginInstallAsync(au.m_siteID, au.m_identifier, Version(au.m_newVersion));
 		}
+	}
+
+	for (uint i = 0; i < removeIndices.Length; i++) {
+		g_availableUpdates.RemoveAt(removeIndices[i]);
 	}
 
 	// Load all plugins in the sorted index

--- a/src/UpdateCheck.as
+++ b/src/UpdateCheck.as
@@ -84,7 +84,7 @@ void CheckForUpdatesAsync()
 		}
 
 		auto plugin = Meta::GetPluginFromSiteID(siteId);
-		if (plugin !is null and plugin.Type != Meta::PluginType::Zip) {
+		if (plugin !is null && plugin.Type != Meta::PluginType::Zip) {
 			continue;
 		}
 

--- a/src/UpdateCheck.as
+++ b/src/UpdateCheck.as
@@ -83,6 +83,11 @@ void CheckForUpdatesAsync()
 			continue;
 		}
 
+		auto plugin = Meta::GetPluginFromSiteID(siteId);
+		if (plugin !is null and plugin.Type != Meta::PluginType::Zip) {
+			continue;
+		}
+
 		warn("New plugin update available for " + info.m_name + ": " + info.m_version.ToString() + " -> " + siteVersion);
 
 		UI::ShowNotification(


### PR DESCRIPTION
I thought this had been fixed a while ago but apparently not. While working on plugins, I keep all mine in folders in the Plugins folder, and while there are some checks to not try to update these plugins, it still happens to me and Plugin Manager (PM) throws an exception when trying to delete the folder.

Specifically:
- I work on a plugin
- I update my toml to a new version number so I can zip a new version
- I submit the new version
- new version gets approved + published
- I relaunch game
- PM sees an update available
- PM tries to delete my plugin folder
- `Script exception: Unable to delete file: Access is denied.`

It's been difficult to reproduce reliably without fully restarting the game. Unloading PM, editing PluginCache.json back to how it was before I launched the game, and loading PM does not reproduce the issue every time. Also, it seems to be inconsistent on which folder plugins it decides it wants to try to update each time.